### PR TITLE
Require Net::IDN::Encode >= 2.100

### DIFF
--- a/META.json
+++ b/META.json
@@ -49,7 +49,7 @@
             "JSON" : "0",
             "List::Util" : "0",
             "List::UtilsBy" : "0",
-            "Net::IDN::Encode" : "0",
+            "Net::IDN::Encode" : "2.100",
             "Path::Tiny" : "0",
             "Unicode::Normalize" : "0",
             "YAML::PP" : "0",

--- a/cpanfile
+++ b/cpanfile
@@ -5,7 +5,7 @@ requires 'File::Share';
 requires 'JSON';
 requires 'List::Util';
 requires 'List::UtilsBy';
-requires 'Net::IDN::Encode';
+requires 'Net::IDN::Encode', '2.100';
 requires 'Path::Tiny';
 requires 'Unicode::Normalize';
 requires 'YAML::PP';


### PR DESCRIPTION
According to [RFC 1034](https://tools.ietf.org/html/rfc1034), each label of a domain must be 63 characters or less.

I expected `Net::IDN::Encode::domain_to_ascii` to raise an exception when `$domain` is an invalid domain. But Net::IDN::Encode <= 2.005 doesn't raise an error although the domain contains a label longer than 63 characters. Because of this, some results of `parse_tweet` subroutine are wrong in [some enviroments where Net::IDN::Encode <= 2.005 is installed](http://www.cpantesters.org/cpan/report/b77f5b5c-6bf4-1014-871f-1eac89ed53e0).

This behavior is fixed in Net::IDN::Encode 2.100.