### PR TITLE
Perl 5.12 compatibility

### DIFF
--- a/META.json
+++ b/META.json
@@ -53,7 +53,7 @@
             "Path::Tiny" : "0",
             "Unicode::Normalize" : "0",
             "YAML::PP" : "0",
-            "perl" : "5.012001"
+            "perl" : "5.012000"
          }
       },
       "test" : {

--- a/META.json
+++ b/META.json
@@ -53,7 +53,7 @@
             "Path::Tiny" : "0",
             "Unicode::Normalize" : "0",
             "YAML::PP" : "0",
-            "perl" : "5.014001"
+            "perl" : "5.012001"
          }
       },
       "test" : {

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.014001';
+requires 'perl', '5.012001';
 requires 'Carp';
 requires 'Exporter';
 requires 'File::Share';

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.012001';
+requires 'perl', '5.012000';
 requires 'Carp';
 requires 'Exporter';
 requires 'File::Share';

--- a/lib/Twitter/Text.pm
+++ b/lib/Twitter/Text.pm
@@ -239,7 +239,9 @@ sub extract_urls_with_indices {
             # last_url only contains domain. Need to add path and query if they exist.
             if ($path) {
                 # last_url was not added. Add it to urls here.
-                $last_url->{url} = $url =~ s/$domain/$last_url->{url}/re;
+                my $last_url_after = $url;
+                $last_url_after =~ s/$domain/$last_url->{url}/e;
+                $last_url->{url} = $last_url_after;
                 $last_url->{indices}->[1] = $end;
             }
         } else {

--- a/lib/Twitter/Text.pm
+++ b/lib/Twitter/Text.pm
@@ -1,5 +1,5 @@
 package Twitter::Text;
-use 5.014001;
+use 5.012001;
 use strict;
 use warnings;
 use utf8;

--- a/lib/Twitter/Text.pm
+++ b/lib/Twitter/Text.pm
@@ -3,6 +3,8 @@ use 5.012001;
 use strict;
 use warnings;
 use utf8;
+no if $^V lt v5.13.9, 'warnings', 'utf8';
+
 use constant {
     DEFAULT_TCO_URL_LENGTHS => {
         short_url_length => 23,

--- a/lib/Twitter/Text.pm
+++ b/lib/Twitter/Text.pm
@@ -1,5 +1,5 @@
 package Twitter::Text;
-use 5.012001;
+use 5.012000;
 use strict;
 use warnings;
 use utf8;

--- a/lib/Twitter/Text/Regexp.pm
+++ b/lib/Twitter/Text/Regexp.pm
@@ -3,6 +3,8 @@ package
 use strict;
 use warnings;
 use utf8;
+no if $^V lt v5.13.9, 'warnings', 'utf8';
+
 use Twitter::Text::Util qw(load_yaml);
 
 # internal use only, do not use this module directly.

--- a/lib/Twitter/Text/Util.pm
+++ b/lib/Twitter/Text/Util.pm
@@ -2,6 +2,7 @@ package
     Twitter::Text::Util; # hide from PAUSE
 use strict;
 use warnings;
+no if $^V lt v5.13.9, 'warnings', 'utf8';
 use Exporter 'import';
 use File::Share qw(dist_file);
 use YAML::PP ();

--- a/t/extract.t
+++ b/t/extract.t
@@ -1,4 +1,5 @@
 use Test2::V0;
+no if $^V lt v5.13.9, 'warnings', 'utf8';
 use Test2::Plugin::NoWarnings;
 BEGIN {
     eval {

--- a/t/tlds.t
+++ b/t/tlds.t
@@ -1,4 +1,6 @@
 use Test2::V0;
+no if $^V lt v5.13.9, 'warnings', 'utf8';
+
 use Test2::Plugin::NoWarnings;
 BEGIN {
     eval {

--- a/t/validate.t
+++ b/t/validate.t
@@ -1,6 +1,6 @@
 use Test2::V0;
 no if $^V lt v5.13.9, 'warnings', 'utf8';
-use Test2::Plugin::NoWarnings;
+use if $^V ge v5.13.9, 'Test2::Plugin::NoWarnings';
 BEGIN {
     eval {
         require Test2::Plugin::GitHub::Actions::AnnotateFailedTest;

--- a/t/validate.t
+++ b/t/validate.t
@@ -1,4 +1,5 @@
 use Test2::V0;
+no if $^V lt v5.13.9, 'warnings', 'utf8';
 use Test2::Plugin::NoWarnings;
 BEGIN {
     eval {

--- a/t/validate.t
+++ b/t/validate.t
@@ -1,6 +1,5 @@
 use Test2::V0;
 no if $^V lt v5.13.9, 'warnings', 'utf8';
-use if $^V ge v5.13.9, 'Test2::Plugin::NoWarnings';
 BEGIN {
     eval {
         require Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
@@ -31,7 +30,12 @@ sub expected_parse_result {
     };
 }
 
+# XXX: "Unicode non-character 0xffff is illegal for interchange" warning occurs in YAML::PP::Lexer in Perl between v5.10.0 and v5.13.8
+# so we want to import Test2::Plugin::NoWarnings after reading YAML files.
+# https://perldoc.perl.org/5.14.2/perl5139delta#Selected-Bug-Fixes
 my $yaml = load_yaml("validate.yml");
+require Test2::Plugin::NoWarnings;
+Test2::Plugin::NoWarnings->import;
 
 subtest tweets => sub {
     my $testcases = $yaml->[0]->{tests}->{tweets};


### PR DESCRIPTION
- avoid to use non-destructive substitution (which is a new feature in Perl 5.14) https://github.com/utgwkk/Twitter-Text/commit/be42de00eea5c70d7a6d309132980ef41121b7e7
- suppress warnings for utf8 in Perl < 5.13.9 https://github.com/utgwkk/Twitter-Text/commit/228109dce34b31c517f71f82212618d3b615a73d https://github.com/utgwkk/Twitter-Text/commit/74dda937c75bded7c2e805ef3834b8cdf59e7970 https://github.com/utgwkk/Twitter-Text/commit/fc831f97fa5f4034d2bda0c6c2c47d47c876b8c9
  - ref: https://perldoc.perl.org/5.14.2/perl5139delta#Selected-Bug-Fixes

Tested with Perl 5.12.5 in Docker container.

```
root@fb1574e12826:~/Twitter-Text# perl -v

This is perl 5, version 12, subversion 5 (v5.12.5) built for x86_64-linux
(with 1 registered patch, see perl -V for more detail)

Copyright 1987-2012, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at http://www.perl.org/, the Perl Home Page.

root@fb1574e12826:~/Twitter-Text# prove -l -Ilocal/lib/perl5 t
t/00_compile.t .. ok
t/extract.t ..... ok
t/tlds.t ........ ok
t/validate.t .... Unicode non-character 0xffff is illegal for interchange at /root/Twitter-Text/local/lib/perl5/YAML/PP/Lexer.pm line 754, <$fh> line 687.
Unicode non-character 0xfffe is illegal for interchange at /root/Twitter-Text/local/lib/perl5/YAML/PP/Lexer.pm line 754, <$fh> line 687.
t/validate.t .... ok
All tests successful.
Files=4, Tests=26,  8 wallclock secs ( 0.13 usr  0.00 sys +  7.99 cusr  0.17 csys =  8.29 CPU)
Result: PASS
root@fb1574e12826:~/Twitter-Text#
```